### PR TITLE
Update Guardrail component to show pass status

### DIFF
--- a/src/app/contexts/TranscriptContext.tsx
+++ b/src/app/contexts/TranscriptContext.tsx
@@ -76,6 +76,12 @@ export const TranscriptProvider: FC<PropsWithChildren> = ({ children }) => {
         createdAtMs: Date.now(),
         status: "IN_PROGRESS",
         isHidden,
+        // Initialize guardrailResult for assistant messages so the chip shows for both pass and fail cases
+        ...(role === "assistant" && {
+          guardrailResult: {
+            status: "IN_PROGRESS",
+          }
+        }),
       };
 
       return [...prev, newItem];


### PR DESCRIPTION
<!-- Initialize guardrail state for assistant messages to display the Guardrail component for both pass and fail results. -->

<!-- Previously, the Guardrail component only rendered when a `guardrailResult` was explicitly set upon failure. This change ensures all assistant messages start with an `IN_PROGRESS` guardrail status, allowing the component to display and be updated to `PASS` when applicable. -->